### PR TITLE
Add scoop installation reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ On Linux, as root:
 Installation
 ------------
 
-On Windows, go to the [Releases page](https://github.com/maharmstone/ntfs2btrfs/releases) and
-download the latest Zip file.
+For Windows:
+* [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/ntfs2btrfs.json)
+
+Or go to the [Releases page](https://github.com/maharmstone/ntfs2btrfs/releases) and
+download the latest zip file.
 
 For Linux:
 * [Arch](https://aur.archlinux.org/packages/ntfs2btrfs-git) (thanks to [nicman23](https://github.com/nicman23))


### PR DESCRIPTION
I have just added [`ntfs2btrfs`](https://github.com/ScoopInstaller/Main/blob/master/bucket/ntfs2btrfs.json) in Scoop, and a reference to it would be great.