### PR TITLE
Add nix flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1661931183,
+        "narHash": "sha256-0+2KzcexiJCB3Il5t7cZAM2RXNRfm5/gMCwhcZJxLuQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97747d3209efde533f7b1b28f1be11619f556a06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+{
+  description = "A tool for in-place conversion of Microsoft's NTFS filesystem to the open-source filesystem Btrfs, much as btrfs-convert does for ext2";
+
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
+
+  outputs = { self, nixpkgs }: {
+
+    defaultPackage.x86_64-linux =
+      with import nixpkgs { system = "x86_64-linux"; };
+      stdenv.mkDerivation {
+        name = "ntfs2btrfs";
+        src = self;
+        buildInputs = [
+          cmake
+          fmt_8
+          pkg-config
+          zlib
+          lzo
+          zstd
+        ];
+        buildPhase = ''
+          cmake .
+          make -j $NIX_BUILD_CORES
+        '';
+        installPhase = "mkdir -p $out/bin; install -t $out/bin ntfs2btrfs";
+      };
+
+  };
+}


### PR DESCRIPTION
If you have [nix](https://nixos.org/download.html) installed with [flakes enabled](https://nixos.wiki/wiki/Flakes), you can get a shell with `ntfs2btrfs` available like so:

```fish
nix shell github:ThibaultLemaire/ntfs2btrfs
```

Nix automatically downloads all required dependencies then builds `ntfs2btrfs` the first time you run this command. (Works on any Linux system.)