### PR TITLE
Use stable release package for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ On Windows, go to the [Releases page](https://github.com/maharmstone/ntfs2btrfs/
 download the latest Zip file, or use [Scoop](https://github.com/ScoopInstaller/Main/blob/master/bucket/ntfs2btrfs.json).
 
 For Linux:
-* [Arch](https://aur.archlinux.org/packages/ntfs2btrfs-git) (thanks to [nicman23](https://github.com/nicman23))
+* [Arch](https://aur.archlinux.org/packages/ntfs2btrfs)
 * [Fedora](https://src.fedoraproject.org/rpms/ntfs2btrfs) (thanks to [Conan-Kudo](https://github.com/Conan-Kudo))
 * [Gentoo ebuild](https://raw.githubusercontent.com/maharmstone/ntfs2btrfs/master/ntfs2btrfs-20220812.ebuild)
 * [Debian](https://packages.debian.org/ntfs2btrfs) (thanks to [alexmyczko](https://github.com/alexmyczko))


### PR DESCRIPTION
Since the `-git` package on the AUR hasn't been updated in over a year with the latest requirements in dependencies and build instructions I submitted a stable release package now that simply uses the latest release tag of the git repo.
I think it would the best to link to a package that uses a stable release instead of the latest master just like it is done for all other Linux distributions (apart from Gentoo).
I didn't want to take credit for myself for this minor task, hence I removed the crediting behind the link but feel free to change that. Maybe even listing both packages would be an option.
