### PR TITLE
ntfs.h: include <memory>

### DIFF
--- a/src/ntfs.h
+++ b/src/ntfs.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <list>
 #include <functional>
+#include <memory>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
when building with libstdc++ from GCC-14, we have
```
In file included from /builddir/build/BUILD/ntfs2btrfs-20240115-build/ntfs2btrfs-20240115/src/ntfs.cpp:21:
/builddir/build/BUILD/ntfs2btrfs-20240115-build/ntfs2btrfs-20240115/src/ntfs.h:537:10: error: â€˜unique_ptrâ€™ in namespace â€˜stdâ€™ does not name a template type
  537 |     std::unique_ptr<ntfs_file> mft;
      |          ^~~~~~~~~~
```

so include <memory> accordingly.